### PR TITLE
(fix): Pass API key in an HTTP header instead of request body

### DIFF
--- a/lib/deep_thought/deepl/api.ex
+++ b/lib/deep_thought/deepl/api.ex
@@ -8,8 +8,14 @@ defmodule DeepThought.DeepL.API do
 
   use Tesla
 
+  @auth_key Application.get_env(:deep_thought, :deepl)[:auth_key]
+
+  @headers [
+    {"Authorization", "DeepL-Auth-Key #{@auth_key}"},
+    {"Content-Type", "application/x-www-form-urlencoded"}
+  ]
+
   plug Tesla.Middleware.BaseUrl, "https://api.deepl.com/v2"
-  plug Tesla.Middleware.Query, auth_key: Application.get_env(:deep_thought, :deepl)[:auth_key]
   plug Tesla.Middleware.EncodeFormUrlencoded
   plug Tesla.Middleware.DecodeJson
   plug Tesla.Middleware.Logger
@@ -20,7 +26,7 @@ defmodule DeepThought.DeepL.API do
   """
   @spec translate(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def translate(text, target_language) do
-    {:ok, response} = post("/translate", translate_request_body(text, target_language))
+    {:ok, response} = post("/translate", translate_request_body(text, target_language), headers: @headers)
 
     case response.status() do
       200 ->

--- a/lib/deep_thought/deepl/api.ex
+++ b/lib/deep_thought/deepl/api.ex
@@ -10,12 +10,8 @@ defmodule DeepThought.DeepL.API do
 
   @auth_key Application.get_env(:deep_thought, :deepl)[:auth_key]
 
-  @headers [
-    {"Authorization", "DeepL-Auth-Key #{@auth_key}"},
-    {"Content-Type", "application/x-www-form-urlencoded"}
-  ]
-
   plug Tesla.Middleware.BaseUrl, "https://api.deepl.com/v2"
+  plug Tesla.Middleware.Headers, [{"Authorization", "DeepL-Auth-Key #{@auth_key}"}]
   plug Tesla.Middleware.EncodeFormUrlencoded
   plug Tesla.Middleware.DecodeJson
   plug Tesla.Middleware.Logger
@@ -26,7 +22,7 @@ defmodule DeepThought.DeepL.API do
   """
   @spec translate(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def translate(text, target_language) do
-    {:ok, response} = post("/translate", translate_request_body(text, target_language), headers: @headers)
+    {:ok, response} = post("/translate", translate_request_body(text, target_language))
 
     case response.status() do
       200 ->


### PR DESCRIPTION
👋 today we noticed that translation bot was not working on Slack:

>Failed to translate due to an unexpected response from translation server

I think I patched this last year https://github.com/Cellane/deep_thought/pull/14 but in the wrong repository, and I just noticed now that this is the correct repo used for GHCR we're using for the deployed container we have:

```
ghcr.io/monstar-lab-oss/deepl-for-slack-elixir:master
```

```
00:37:21.909 [info] GET https://slack.com/api/conversations.replies -> 200 (313.530 ms)
00:37:22.002 request_id=GJn1fCXXXXXXMBWQ8h [info] GET /
00:37:22.002 request_id=GJn1fXXXXXXXrdMBWQ8h [info] Sent 200 in 275µs
00:37:22.979 [error] POST https://api.deepl.com/v2/translate -> 403 (1069.876 ms)
```

[Docs](https://developers.deepl.com/docs/getting-started/intro#http-request:~:text=Authorization%3A%20DeepL%2DAuth%2DKey%20%5ByourAuthKey%5D)

Thank you! 🫡 